### PR TITLE
Move AppWrapper to page files instead of components

### DIFF
--- a/supply-chain/src/components/__tests__/__snapshots__/dashboard.js.snap
+++ b/supply-chain/src/components/__tests__/__snapshots__/dashboard.js.snap
@@ -3,3359 +3,3091 @@
 exports[`Dashboard renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="app-wrapper css-o20pkj-wrapperStyles"
+    style="max-width: 1500px;"
   >
-    <header
-      class="eto-header css-1c57aw7-wrapperStyles"
-    >
-      <a
-        href="https://eto.tech/"
-        style="display: flex;"
-      >
-        <img
-          alt="ETO Logo"
-          src="test-file-stub"
-          style="height: 120px;"
-        />
-      </a>
-      <div
-        class="header-links css-18f1a9i-linkStyles"
-      >
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/tools"
-        >
-          Tools
-        </a>
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/datasets"
-        >
-          Data
-        </a>
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/blog"
-        >
-          Blog
-        </a>
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/support"
-        >
-          Help
-        </a>
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/#subscribe"
-        >
-          Subscribe
-        </a>
-      </div>
-    </header>
     <div
-      style="display: flex; flex-direction: column;"
+      class="info-card-wrapper css-1dqxhzn-infocardWrapper-InfoCard"
     >
       <div
-        style="max-width: 1500px;"
+        class="css-f9vkxs-accent"
+      />
+      <div
+        class="css-1sz4i1e-bottomBorderGridArea-topAreaBottomBorder-InfoCard"
+      />
+      <div
+        class="css-l151mc-topAreaBottomBorder-titleWrapper-InfoCard"
       >
         <div
-          class="info-card-wrapper css-1dqxhzn-infocardWrapper-InfoCard"
+          class="MuiTypography-root MuiTypography-h4 css-zlcs7i-MuiTypography-root-title"
         >
-          <div
-            class="css-f9vkxs-accent"
-          />
-          <div
-            class="css-1sz4i1e-bottomBorderGridArea-topAreaBottomBorder-InfoCard"
-          />
-          <div
-            class="css-l151mc-topAreaBottomBorder-titleWrapper-InfoCard"
+          Supply Chain Explorer
+        </div>
+        <div
+          class="css-kwnkor-documentationLink"
+        >
+          <a
+            href="https://eto.tech/tool-docs/chipexplorer/"
+            rel="noopener"
+            target="_blank"
           >
-            <div
-              class="MuiTypography-root MuiTypography-h4 css-zlcs7i-MuiTypography-root-title"
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
+              data-testid="InfoIcon"
+              focusable="false"
+              style="margin-bottom: -5px; margin-right: 5px;"
+              viewBox="0 0 24 24"
             >
-              Supply Chain Explorer
-            </div>
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+              />
+            </svg>
+            Documentation
+          </a>
+        </div>
+      </div>
+      <div
+        class="description-wrapper css-1k40fej-descriptionWrapper"
+      >
+        <div
+          class="description css-l9xykp-description"
+        >
+          <div>
+            ETO's Supply Chain Explorer is designed to quickly orient non-experts to the essential inputs, players, and relationships involved in producing advanced computer chips. Use the Explorer to learn how these chips are made, who makes them, and the tools, materials, and processes involved in the supply chain.
             <div
-              class="css-kwnkor-documentationLink"
+              class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+              style="padding-top: 15px;"
             >
+              <strong>
+                Learn more:
+              </strong>
+               
               <a
-                href="https://eto.tech/tool-docs/chipexplorer/"
+                href="https://eto.tech/tool-docs/chipexplorer"
                 rel="noopener"
                 target="_blank"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
-                  data-testid="InfoIcon"
-                  focusable="false"
-                  style="margin-bottom: -5px; margin-right: 5px;"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
-                  />
-                </svg>
                 Documentation
               </a>
-            </div>
-          </div>
-          <div
-            class="description-wrapper css-1k40fej-descriptionWrapper"
-          >
-            <div
-              class="description css-l9xykp-description"
-            >
-              <div>
-                ETO's Supply Chain Explorer is designed to quickly orient non-experts to the essential inputs, players, and relationships involved in producing advanced computer chips. Use the Explorer to learn how these chips are made, who makes them, and the tools, materials, and processes involved in the supply chain.
-                <div
-                  class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                  style="padding-top: 15px;"
-                >
-                  <strong>
-                    Learn more:
-                  </strong>
-                   
-                  <a
-                    href="https://eto.tech/tool-docs/chipexplorer"
-                    rel="noopener"
-                    target="_blank"
-                  >
-                    Documentation
-                  </a>
-                  <span
-                    style="padding: 0px 10px;"
-                  >
-                    |
-                  </span>
-                  Blog post: 
-                  <a
-                    href="https://eto.tech/blog/five-takeaways-chip-supply-chain"
-                    rel="noopener"
-                    target="_blank"
-                  >
-                    Five quick takeaways on the chip supply chain
-                  </a>
-                  <span
-                    style="padding: 0px 10px;"
-                  >
-                    |
-                  </span>
-                  <a
-                    href="https://eto.tech/blog/?tag=Supply%20Chain%20Explorer"
-                    rel="noopener"
-                    target="_blank"
-                  >
-                    All Explorer blog posts
-                  </a>
-                  <p>
-                    Last updated on January 31, 2022. Underlying data originally published in 2021.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="MuiTypography-root MuiTypography-p sidebar-title desktop css-mp08le-MuiTypography-root-topAreaBottomBorder-sidebarCommon-sidebarTitle-InfoCard"
-          >
-            Quick guide
-          </div>
-          <div
-            class="MuiTypography-root MuiTypography-p sidebar-content desktop css-aocfr6-MuiTypography-root-sidebarCommon-sidebarContent-InfoCard"
-          >
-            <div>
-              <div
-                style="padding-bottom: 15px;"
+              <span
+                style="padding: 0px 10px;"
               >
-                Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.
-              </div>
-              <div>
-                Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.
-              </div>
-            </div>
-          </div>
-          <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sidebar-mobile css-11agvpd-MuiPaper-root-MuiAccordion-root-sidebarMobile"
-          >
-            <div
-              aria-controls="sidebar-content"
-              aria-expanded="false"
-              class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1f773le-MuiButtonBase-root-MuiAccordionSummary-root"
-              id="sidebar-header"
-              role="button"
-              tabindex="0"
-            >
-              <div
-                class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-eqpfi5-MuiAccordionSummary-content"
+                |
+              </span>
+              Blog post: 
+              <a
+                href="https://eto.tech/blog/five-takeaways-chip-supply-chain"
+                rel="noopener"
+                target="_blank"
               >
-                <div
-                  class="MuiTypography-root MuiTypography-p sidebar-title css-1d3drjq-MuiTypography-root-topAreaBottomBorder-sidebarCommon-sidebarTitle-InfoCard"
-                >
-                  Quick guide
-                </div>
-              </div>
-              <div
-                class="MuiAccordionSummary-expandIconWrapper css-yw020d-MuiAccordionSummary-expandIconWrapper"
+                Five quick takeaways on the chip supply chain
+              </a>
+              <span
+                style="padding: 0px 10px;"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                  data-testid="ExpandMoreIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  />
-                </svg>
-              </div>
-            </div>
-            <div
-              class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
-              style="min-height: 0px;"
-            >
-              <div
-                class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+                |
+              </span>
+              <a
+                href="https://eto.tech/blog/?tag=Supply%20Chain%20Explorer"
+                rel="noopener"
+                target="_blank"
               >
-                <div
-                  class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-                >
-                  <div
-                    aria-labelledby="sidebar-header"
-                    class="MuiAccordion-region"
-                    id="sidebar-content"
-                    role="region"
-                  >
-                    <div
-                      class="MuiAccordionDetails-root css-15v22id-MuiAccordionDetails-root"
-                    >
-                      <div
-                        class="MuiTypography-root MuiTypography-p sidebar-content css-4gtl7g-MuiTypography-root-sidebarCommon-sidebarContent-InfoCard"
-                      >
-                        <div>
-                          <div
-                            style="padding-bottom: 15px;"
-                          >
-                            Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.
-                          </div>
-                          <div>
-                            Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+                All Explorer blog posts
+              </a>
+              <p>
+                Last updated on January 31, 2022. Underlying data originally published in 2021.
+              </p>
             </div>
           </div>
         </div>
       </div>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 filter-bar css-ee20y-MuiPaper-root"
-        style="position: sticky; top: 0px; z-index: 20;"
+        class="MuiTypography-root MuiTypography-p sidebar-title desktop css-mp08le-MuiTypography-root-topAreaBottomBorder-sidebarCommon-sidebarTitle-InfoCard"
       >
-        <div
-          class="dropdown css-1fq48ug-dropdownWrapper-Dropdown"
-        >
-          <div
-            class="MuiFormControl-root css-2m9kme-MuiFormControl-root"
-          >
-            <div
-              class="css-13b7bh9-label-Dropdown"
-            >
-              <label
-                class=""
-                id="Highlight-by-label"
-              >
-                Highlight by
-              </label>
-            </div>
-            <div
-              class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select css-19njw3j-MuiInputBase-root-MuiInput-root-MuiSelect-root-select"
-            >
-              <div
-                aria-controls=":r0:"
-                aria-expanded="false"
-                aria-haspopup="listbox"
-                aria-labelledby="Highlight-by-label Highlight-by"
-                class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
-                id="Highlight-by"
-                role="combobox"
-                tabindex="0"
-              >
-                None
-              </div>
-              <input
-                aria-hidden="true"
-                aria-invalid="false"
-                class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
-                tabindex="-1"
-                value="None"
-              />
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
-                data-testid="ArrowDropDownIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M7 10l5 5 5-5z"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-        <button
-          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
-          id="clear-button"
-          tabindex="0"
-          type="button"
-        >
-          Clear Highlights
-          <span
-            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-          />
-        </button>
-        <div
-          class="user-feedback-wrapper css-17v8ss5-targetWrapper"
-        >
-          <button
-            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
-            data-testid="userfeedback-trigger"
-            tabindex="0"
-            type="button"
-          >
-            <span
-              class="helptooltip css-hr1mel-wrapper"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium feedback-icon css-buj1li-MuiSvgIcon-root-HelpTooltip"
-                data-mui-internal-clone-element="true"
-                data-testid="FeedbackOutlinedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 14H5.17l-.59.59-.58.58V4h16zm-9-4h2v2h-2zm0-6h2v4h-2z"
-                />
-              </svg>
-            </span>
-            <span
-              class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-            />
-          </button>
-        </div>
+        Quick guide
       </div>
       <div
-        style="display: inline-block; text-align: center; background-color: white;"
+        class="MuiTypography-root MuiTypography-p sidebar-content desktop css-aocfr6-MuiTypography-root-sidebarCommon-sidebarContent-InfoCard"
       >
-        <div
-          class="map-background"
-        >
+        <div>
+          <div
+            style="padding-bottom: 15px;"
+          >
+            Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.
+          </div>
           <div>
-            <div>
-              <div>
-                <div
-                  class="stage-node-wrapper"
-                >
-                  <div
-                    class="uncolored"
-                    style="height: 20px;"
-                  />
-                  <div
-                    class="stage-node "
-                    id="S1"
-                    style="text-align: left;"
-                  >
-                    <h3
-                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                      style="text-align: left; padding-left: 5px; display: inline-block;"
-                    >
-                      Design
-                    </h3>
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
-                      style="padding: 0px 10px 0px 0px;"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                        data-testid="InfoIcon"
-                        focusable="false"
-                        style="vertical-align: top;"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
-                        />
-                      </svg>
-                       General overview
-                    </button>
-                  </div>
-                </div>
-              </div>
+            Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters sidebar-mobile css-11agvpd-MuiPaper-root-MuiAccordion-root-sidebarMobile"
+      >
+        <div
+          aria-controls="sidebar-content"
+          aria-expanded="false"
+          class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1f773le-MuiButtonBase-root-MuiAccordionSummary-root"
+          id="sidebar-header"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-eqpfi5-MuiAccordionSummary-content"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-p sidebar-title css-1d3drjq-MuiTypography-root-topAreaBottomBorder-sidebarCommon-sidebarTitle-InfoCard"
+            >
+              Quick guide
             </div>
-            <div>
+          </div>
+          <div
+            class="MuiAccordionSummary-expandIconWrapper css-yw020d-MuiAccordionSummary-expandIconWrapper"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="ExpandMoreIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-bz4dnt-MuiCollapse-root"
+          style="min-height: 0px;"
+        >
+          <div
+            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
+          >
+            <div
+              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
+            >
               <div
-                class="stage-border"
+                aria-labelledby="sidebar-header"
+                class="MuiAccordion-region"
+                id="sidebar-content"
+                role="region"
               >
                 <div
-                  class="graph-node-wrapper"
+                  class="MuiAccordionDetails-root css-15v22id-MuiAccordionDetails-root"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N1"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+                    class="MuiTypography-root MuiTypography-p sidebar-content css-4gtl7g-MuiTypography-root-sidebarCommon-sidebarContent-InfoCard"
                   >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Logic chip design: Advanced CPUs
-                        </h3>
-                      </div>
+                    <div>
                       <div
-                        class="graph-node-connections-text"
-                      />
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N85"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Core intellectual property
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N84"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic design automation software
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N2"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Logic chip design: Discrete GPUs
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      />
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N85"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Core intellectual property
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N84"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic design automation software
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-            </div>
-            <div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N3"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Logic chip design: FPGAs
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      />
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N85"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Core intellectual property
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N84"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic design automation software
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N4"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Logic chip design: AI ASICs
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      />
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N85"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Core intellectual property
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N84"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic design automation software
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-            </div>
-            <div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-                <span />
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-                <span />
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-                <span />
-                <span />
-              </div>
-              <div
-                class="graph-arrows-wrapper"
-              >
-                <span />
-                <span />
-              </div>
-              <div
-                class="stage-border uncolored"
-              >
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div>
-                <div
-                  class="stage-node-wrapper"
-                >
-                  <div
-                    class="uncolored"
-                    style="height: 20px;"
-                  />
-                  <div
-                    class="stage-node "
-                    id="S2"
-                    style="text-align: left;"
-                  >
-                    <h3
-                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                      style="text-align: left; padding-left: 5px; display: inline-block;"
-                    >
-                      Fabrication
-                    </h3>
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
-                      style="padding: 0px 10px 0px 0px;"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                        data-testid="InfoIcon"
-                        focusable="false"
-                        style="vertical-align: top;"
-                        viewBox="0 0 24 24"
+                        style="padding-bottom: 15px;"
                       >
-                        <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
-                        />
-                      </svg>
-                       General overview
-                    </button>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N59"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Wafer and photomask handling
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Deposition, Photolithography, Etch and clean, Chemical mechanical planarization
-                          </span>
-                        </div>
+                        Click on any part of the diagram to view a summary description, supplier countries, and supplier companies.
                       </div>
                       <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N12"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Photomask handlers
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N11"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wafer handlers
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
+                        Use the filter bar at the top to jump to a specific input, or to highlight different parts of the diagram according to countries, companies, or market concentration.
                       </div>
                     </div>
                   </div>
                 </div>
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N35"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Deposition
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Wafer and photomask handling, Process control
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Photolithography
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N88"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Deposition materials
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N36"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Deposition tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N91"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic gases
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N26"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wafer
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div>
-                                    <div>
-                                      <div
-                                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                        id="N8"
-                                      >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                        >
-                                          <span
-                                            class="graph-node-icon"
-                                            style="margin-left: 10px;"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                              focusable="false"
-                                              id="a"
-                                              style="fill-rule: evenodd; margin: -8px 0px;"
-                                              viewBox="0 0 44 44"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                class="b"
-                                                d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                              />
-                                            </svg>
-                                          </span>
-                                          <span>
-                                            Crystal growing furnaces
-                                          </span>
-                                        </p>
-                                      </div>
-                                      <div
-                                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                      >
-                                        <div />
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div>
-                                      <div
-                                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                        id="N9"
-                                      >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                        >
-                                          <span
-                                            class="graph-node-icon"
-                                            style="margin-left: 10px;"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                              focusable="false"
-                                              id="a"
-                                              style="fill-rule: evenodd; margin: -8px 0px;"
-                                              viewBox="0 0 44 44"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                class="b"
-                                                d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                              />
-                                            </svg>
-                                          </span>
-                                          <span>
-                                            Crystal machining tools
-                                          </span>
-                                        </p>
-                                      </div>
-                                      <div
-                                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                      >
-                                        <div />
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div>
-                                      <div
-                                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                        id="N17"
-                                      >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                        >
-                                          <span
-                                            class="graph-node-icon"
-                                            style="margin-left: 10px;"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                              focusable="false"
-                                              id="a"
-                                              style="fill-rule: evenodd; margin: -8px 0px;"
-                                              viewBox="0 0 44 44"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                class="b"
-                                                d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                              />
-                                            </svg>
-                                          </span>
-                                          <span>
-                                            Ion implanters
-                                          </span>
-                                        </p>
-                                      </div>
-                                      <div
-                                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                      >
-                                        <div />
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div>
-                                      <div
-                                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                        id="N10"
-                                      >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                        >
-                                          <span
-                                            class="graph-node-icon"
-                                            style="margin-left: 10px;"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                              focusable="false"
-                                              id="a"
-                                              style="fill-rule: evenodd; margin: -8px 0px;"
-                                              viewBox="0 0 44 44"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                class="b"
-                                                d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                              />
-                                            </svg>
-                                          </span>
-                                          <span>
-                                            Wafer bonding and aligning tools
-                                          </span>
-                                        </p>
-                                      </div>
-                                      <div
-                                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                      >
-                                        <div />
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N92"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wet chemicals
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N60"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Process control
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Deposition, Photolithography, Etch and clean, Chemical mechanical planarization
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N62"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Photomask inspection and repair tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N64"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Process monitoring equipment
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N61"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wafer inspection equipment
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N63"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wafer level packaging inspection tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N25"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Photolithography
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Deposition, Wafer and photomask handling, Process control
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Etch and clean
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N19"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Advanced photolithography equipment
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N33"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Advanced photomasks
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div>
-                                    <div>
-                                      <div
-                                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                        id="N28"
-                                      >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                        >
-                                          <span
-                                            class="graph-node-icon"
-                                            style="margin-left: 10px;"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                              focusable="false"
-                                              id="a"
-                                              style="fill-rule: evenodd; margin: -8px 0px;"
-                                              viewBox="0 0 44 44"
-                                              xmlns="http://www.w3.org/2000/svg"
-                                            >
-                                              <path
-                                                class="b"
-                                                d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                              />
-                                            </svg>
-                                          </span>
-                                          <span>
-                                            Maskless lithography equipment
-                                          </span>
-                                        </p>
-                                      </div>
-                                      <div
-                                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                      >
-                                        <div />
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N91"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic gases
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N31"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Photoresists
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N32"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Resist processing tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N92"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wet chemicals
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N46"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Etch and clean
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Photolithography, Wafer and photomask handling, Process control
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Chemical mechanical planarization
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N91"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic gases
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N55"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Etching and cleaning tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N92"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wet chemicals
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N57"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Chemical mechanical planarization
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Etch and clean, Wafer and photomask handling, Process control
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Assembly and packaging
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N86"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Chemical mechanical planarization tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N90"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      CMP materials
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N91"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic gases
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N92"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Wet chemicals
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div>
-                <div
-                  class="stage-node-wrapper"
-                >
-                  <div
-                    class="uncolored"
-                    style="height: 20px;"
-                  />
-                  <div
-                    class="stage-node "
-                    id="S3"
-                    style="text-align: left;"
-                  >
-                    <h3
-                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                      style="text-align: left; padding-left: 5px; display: inline-block;"
-                    >
-                      Assembly, testing, and packaging (ATP)
-                    </h3>
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
-                      style="padding: 0px 10px 0px 0px;"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                        data-testid="InfoIcon"
-                        focusable="false"
-                        style="vertical-align: top;"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
-                        />
-                      </svg>
-                       General overview
-                    </button>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N69"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Assembly and packaging
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Chemical mechanical planarization
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Testing
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N70"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Assembly inspection tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N72"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Bonding tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N71"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Dicing tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N91"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Electronic gases
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N77"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Integrated assembly tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N100"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Packaging materials
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N76"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Packaging tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div
-                class="stage-border"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N78"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Testing
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Assembly and packaging
-                          </span>
-                        </div>
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Dependent processes:
-                          </span>
-                          <span>
-                            Finished logic chip
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N81"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Burn-in test equipment
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N83"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Handlers and probes
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N82"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      Linear and discrete testing tools
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div>
-                                <div
-                                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
-                                  id="N80"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
-                                  >
-                                    <span
-                                      class="graph-node-icon"
-                                      style="margin-left: 0px;"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
-                                        focusable="false"
-                                        id="a"
-                                        style="fill-rule: evenodd; margin: -8px 0px;"
-                                        viewBox="0 0 44 44"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                      >
-                                        <path
-                                          class="b"
-                                          d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span>
-                                      SoC test equipment
-                                    </span>
-                                  </p>
-                                </div>
-                                <div
-                                  class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                                >
-                                  <div />
-                                </div>
-                              </div>
-                            </div>
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
-              </div>
-              <div
-                class="stage-border uncolored"
-              >
-                <div
-                  class="graph-node-wrapper"
-                >
-                  <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
-                    id="N99"
-                    style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
-                  >
-                    <div
-                      style="text-align: left;"
-                    >
-                      <div>
-                        <h3
-                          class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
-                        >
-                          Finished logic chip
-                        </h3>
-                      </div>
-                      <div
-                        class="graph-node-connections-text"
-                      >
-                        <div
-                          class="connection-text"
-                        >
-                          <span
-                            class="bold"
-                          >
-                            Input processes:
-                          </span>
-                          <span>
-                            Testing
-                          </span>
-                        </div>
-                      </div>
-                      <div>
-                        <div>
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
-                          >
-                            <div />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="documentation-node-widescreen"
-                />
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <footer
-      class="eto-footer css-qosz01-wrapperStyles"
+  </div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 filter-bar css-ee20y-MuiPaper-root"
+    style="position: sticky; top: 0px; z-index: 20;"
+  >
+    <div
+      class="dropdown css-1fq48ug-dropdownWrapper-Dropdown"
     >
       <div
-        class="css-1bvzjq5-brandStyles"
+        class="MuiFormControl-root css-2m9kme-MuiFormControl-root"
       >
         <div
-          class="css-1m9z1cc-logoStyles"
+          class="css-13b7bh9-label-Dropdown"
         >
-          <a
-            href="https://eto.tech/"
+          <label
+            class=""
+            id="Highlight-by-label"
           >
-            <img
-              alt="ETO Logo"
-              src="test-file-stub"
-              style="height: 90px;"
-            />
-          </a>
-          <a
-            href="https://cset.georgetown.edu"
-          >
-            <img
-              alt="Center for Security and Emerging Technology logo"
-              class="cset-logo"
-              src="test-file-stub"
-            />
-          </a>
+            Highlight by
+          </label>
         </div>
         <div
-          class="css-127x865-textBlurbStyles"
+          class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl select css-19njw3j-MuiInputBase-root-MuiInput-root-MuiSelect-root-select"
         >
-          ETO is a project of the 
-          <a
-            href="https://cset.georgetown.edu/"
-            rel="noopener"
-            target="_blank"
+          <div
+            aria-controls=":r0:"
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="Highlight-by-label Highlight-by"
+            class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input css-1rxz5jq-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+            id="Highlight-by"
+            role="combobox"
+            tabindex="0"
           >
-            Center for Security and Emerging Technology
-          </a>
-           at 
-          <a
-            href="https://www.georgetown.edu/"
-            rel="noopener"
-            target="_blank"
+            None
+          </div>
+          <input
+            aria-hidden="true"
+            aria-invalid="false"
+            class="MuiSelect-nativeInput css-yf8vq0-MuiSelect-nativeInput"
+            tabindex="-1"
+            value="None"
+          />
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconStandard css-pqjvzy-MuiSvgIcon-root-MuiSelect-icon"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            Georgetown University
-          </a>
-          .
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
         </div>
       </div>
-      <div
-        class="subscribebox--core css-qvd9sj-subscribeBoxCore-subscribeBox"
+    </div>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-1rwt2y5-MuiButtonBase-root-MuiButton-root"
+      id="clear-button"
+      tabindex="0"
+      type="button"
+    >
+      Clear Highlights
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+    <div
+      class="user-feedback-wrapper css-17v8ss5-targetWrapper"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1pe4mpk-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="userfeedback-trigger"
+        tabindex="0"
+        type="button"
       >
-        <div
-          class="subscribe-inner"
+        <span
+          class="helptooltip css-hr1mel-wrapper"
         >
-          <h3>
-            Get updates
-          </h3>
-          <label
-            class="plain css-ynzfad-subscribeBoxLabel"
-            for="subscriptionFooter"
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium feedback-icon css-buj1li-MuiSvgIcon-root-HelpTooltip"
+            data-mui-internal-clone-element="true"
+            data-testid="FeedbackOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            Sign up for the latest ETO analysis, news, and product updates.
-          </label>
-          <div
-            class="email-form subscribebox--form css-1aiowzb-subscribeBoxInputWrapper"
-          >
+            <path
+              d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 14H5.17l-.59.59-.58.58V4h16zm-9-4h2v2h-2zm0-6h2v4h-2z"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    style="display: inline-block; text-align: center; background-color: white;"
+  >
+    <div
+      class="map-background"
+    >
+      <div>
+        <div>
+          <div>
             <div
-              class="css-osokpe-inputOrErrorMessage"
-              data-testid="email-form-result"
+              class="stage-node-wrapper"
             >
               <div
-                class="MuiFormControl-root MuiTextField-root css-11kv24h-MuiFormControl-root-MuiTextField-root-baseStyles-customColorStyles-TextFieldStyled"
-                style="margin-right: 0.5rem; width: 100%;"
+                class="uncolored"
+                style="height: 20px;"
+              />
+              <div
+                class="stage-node "
+                id="S1"
+                style="text-align: left;"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                  style="text-align: left; padding-left: 5px; display: inline-block;"
+                >
+                  Design
+                </h3>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  style="padding: 0px 10px 0px 0px;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="InfoIcon"
+                    focusable="false"
+                    style="vertical-align: top;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+                    />
+                  </svg>
+                   General overview
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N1"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
               >
                 <div
-                  class="MuiInputBase-root MuiInput-root MuiInputBase-colorPrimary MuiInputBase-formControl css-1aa5qj0-MuiInputBase-root-MuiInput-root"
+                  style="text-align: left;"
                 >
-                  <input
-                    aria-invalid="false"
-                    class="MuiInputBase-input MuiInput-input css-1x51dt5-MuiInputBase-input-MuiInput-input"
-                    id="subscriptionFooter"
-                    placeholder="you@example.com"
-                    type="text"
-                    value=""
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Logic chip design: Advanced CPUs
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
                   />
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N85"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Core intellectual property
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N84"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic design automation software
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-5nq1g3-MuiButtonBase-root-MuiButton-root-styles-ButtonStyled"
-              tabindex="0"
-              title="Submit email"
-              type="button"
+            <div
+              class="graph-node-wrapper"
             >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-                data-testid="ArrowForwardIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N2"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
               >
-                <path
-                  d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                />
-              </svg>
-              <span
-                class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-              />
-            </button>
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Logic chip design: Discrete GPUs
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  />
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N85"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Core intellectual property
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N84"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic design automation software
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
           </div>
         </div>
-      </div>
-      <div
-        class="contact css-1bnex2w-contactStyles"
-      >
-        <h3>
-          Keep in touch
-        </h3>
         <div>
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-            href="https://twitter.com/EmergingTechObs"
-            rel="noopener"
-            target="_blank"
+          <div
+            class="stage-border"
           >
-            Twitter
-          </a>
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N3"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Logic chip design: FPGAs
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  />
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N85"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Core intellectual property
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N84"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic design automation software
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N4"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Logic chip design: AI ASICs
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  />
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N85"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Core intellectual property
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N84"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic design automation software
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
         </div>
         <div>
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-            href="https://www.linkedin.com/company/emerging-technology-observatory"
-            rel="noopener"
-            target="_blank"
+          <div
+            class="graph-arrows-wrapper"
           >
-            LinkedIn
-          </a>
-        </div>
-        <div>
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-            href="https://etoblog.substack.com/"
-            rel="noopener"
-            target="_blank"
-          >
-            Substack
-          </a>
-        </div>
-        <div>
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-            href="mailto:cset_eto@georgetown.edu"
-            rel="noopener"
-            target="_blank"
-          >
-            Email
-          </a>
-        </div>
-        <div>
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-            href="https://eto.tech/rss.xml"
-            rel="noopener"
-            target="_blank"
-          >
-            RSS
-          </a>
-        </div>
-      </div>
-      <div
-        class="css-1bl0spk-lineStyles"
-      >
-        <div
-          class="line-internal"
-        />
-      </div>
-      <div
-        class="links css-vss5za-linksStyles"
-      >
-        <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-1xylxj1-MuiTypography-root-MuiLink-root"
-          href="https://eto.tech/tou"
-        >
-          Terms of Use and Privacy Policy
-        </a>
-        <div
-          class="css-14jcibu-copyrightNoticeStyles"
-        >
-          <div>
-            ETO, 2024
+            <span />
           </div>
           <div
-            class="divider"
+            class="graph-arrows-wrapper"
           >
-            |
+            <span />
+          </div>
+          <div
+            class="graph-arrows-wrapper"
+          >
+            <span />
+          </div>
+          <div
+            class="graph-arrows-wrapper"
+          >
+            <span />
+            <span />
+            <span />
+          </div>
+          <div
+            class="graph-arrows-wrapper"
+          >
+            <span />
+            <span />
+            <span />
+          </div>
+          <div
+            class="graph-arrows-wrapper"
+          >
+            <span />
+            <span />
+            <span />
+          </div>
+          <div
+            class="graph-arrows-wrapper"
+          >
+            <span />
+            <span />
+          </div>
+          <div
+            class="stage-border uncolored"
+          >
+            <div
+              class="documentation-node-widescreen"
+            />
           </div>
           <div>
-            Designed by 
-            <a
-              href="https://and-now.co.uk/"
-              rel="noopener"
-              style="white-space: nowrap;"
-              target="_blank"
+            <div
+              class="stage-node-wrapper"
             >
-              And-Now
-            </a>
+              <div
+                class="uncolored"
+                style="height: 20px;"
+              />
+              <div
+                class="stage-node "
+                id="S2"
+                style="text-align: left;"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                  style="text-align: left; padding-left: 5px; display: inline-block;"
+                >
+                  Fabrication
+                </h3>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  style="padding: 0px 10px 0px 0px;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="InfoIcon"
+                    focusable="false"
+                    style="vertical-align: top;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+                    />
+                  </svg>
+                   General overview
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N59"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Wafer and photomask handling
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Deposition, Photolithography, Etch and clean, Chemical mechanical planarization
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N12"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Photomask handlers
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N11"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wafer handlers
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N35"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Deposition
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Wafer and photomask handling, Process control
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Photolithography
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N88"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Deposition materials
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N36"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Deposition tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N91"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic gases
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N26"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wafer
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div>
+                                <div>
+                                  <div
+                                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                                    id="N8"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                                    >
+                                      <span
+                                        class="graph-node-icon"
+                                        style="margin-left: 10px;"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                          focusable="false"
+                                          id="a"
+                                          style="fill-rule: evenodd; margin: -8px 0px;"
+                                          viewBox="0 0 44 44"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            class="b"
+                                            d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span>
+                                        Crystal growing furnaces
+                                      </span>
+                                    </p>
+                                  </div>
+                                  <div
+                                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                                  >
+                                    <div />
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <div>
+                                  <div
+                                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                                    id="N9"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                                    >
+                                      <span
+                                        class="graph-node-icon"
+                                        style="margin-left: 10px;"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                          focusable="false"
+                                          id="a"
+                                          style="fill-rule: evenodd; margin: -8px 0px;"
+                                          viewBox="0 0 44 44"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            class="b"
+                                            d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span>
+                                        Crystal machining tools
+                                      </span>
+                                    </p>
+                                  </div>
+                                  <div
+                                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                                  >
+                                    <div />
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <div>
+                                  <div
+                                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                                    id="N17"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                                    >
+                                      <span
+                                        class="graph-node-icon"
+                                        style="margin-left: 10px;"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                          focusable="false"
+                                          id="a"
+                                          style="fill-rule: evenodd; margin: -8px 0px;"
+                                          viewBox="0 0 44 44"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            class="b"
+                                            d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span>
+                                        Ion implanters
+                                      </span>
+                                    </p>
+                                  </div>
+                                  <div
+                                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                                  >
+                                    <div />
+                                  </div>
+                                </div>
+                              </div>
+                              <div>
+                                <div>
+                                  <div
+                                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                                    id="N10"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                                    >
+                                      <span
+                                        class="graph-node-icon"
+                                        style="margin-left: 10px;"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                          focusable="false"
+                                          id="a"
+                                          style="fill-rule: evenodd; margin: -8px 0px;"
+                                          viewBox="0 0 44 44"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            class="b"
+                                            d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span>
+                                        Wafer bonding and aligning tools
+                                      </span>
+                                    </p>
+                                  </div>
+                                  <div
+                                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                                  >
+                                    <div />
+                                  </div>
+                                </div>
+                              </div>
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N92"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wet chemicals
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N60"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Process control
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Deposition, Photolithography, Etch and clean, Chemical mechanical planarization
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N62"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Photomask inspection and repair tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N64"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Process monitoring equipment
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N61"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wafer inspection equipment
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N63"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wafer level packaging inspection tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N25"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Photolithography
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Deposition, Wafer and photomask handling, Process control
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Etch and clean
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N19"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Advanced photolithography equipment
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N33"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Advanced photomasks
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div>
+                                <div>
+                                  <div
+                                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                                    id="N28"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                                    >
+                                      <span
+                                        class="graph-node-icon"
+                                        style="margin-left: 10px;"
+                                      >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                          focusable="false"
+                                          id="a"
+                                          style="fill-rule: evenodd; margin: -8px 0px;"
+                                          viewBox="0 0 44 44"
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            class="b"
+                                            d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                          />
+                                        </svg>
+                                      </span>
+                                      <span>
+                                        Maskless lithography equipment
+                                      </span>
+                                    </p>
+                                  </div>
+                                  <div
+                                    class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                                  >
+                                    <div />
+                                  </div>
+                                </div>
+                              </div>
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N91"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic gases
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N31"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Photoresists
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N32"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Resist processing tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N92"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wet chemicals
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N46"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Etch and clean
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Photolithography, Wafer and photomask handling, Process control
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Chemical mechanical planarization
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N91"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic gases
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N55"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Etching and cleaning tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N92"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wet chemicals
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N57"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Chemical mechanical planarization
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Etch and clean, Wafer and photomask handling, Process control
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Assembly and packaging
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N86"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Chemical mechanical planarization tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N90"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  CMP materials
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N91"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic gases
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N92"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Wet chemicals
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div>
+            <div
+              class="stage-node-wrapper"
+            >
+              <div
+                class="uncolored"
+                style="height: 20px;"
+              />
+              <div
+                class="stage-node "
+                id="S3"
+                style="text-align: left;"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                  style="text-align: left; padding-left: 5px; display: inline-block;"
+                >
+                  Assembly, testing, and packaging (ATP)
+                </h3>
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  style="padding: 0px 10px 0px 0px;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                    data-testid="InfoIcon"
+                    focusable="false"
+                    style="vertical-align: top;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 15h-2v-6h2zm0-8h-2V7h2z"
+                    />
+                  </svg>
+                   General overview
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N69"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Assembly and packaging
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Chemical mechanical planarization
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Testing
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N70"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Assembly inspection tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N72"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Bonding tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N71"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Dicing tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N91"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Electronic gases
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N77"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Integrated assembly tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N100"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Packaging materials
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N76"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Packaging tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div
+            class="stage-border"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N78"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Testing
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Assembly and packaging
+                      </span>
+                    </div>
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Dependent processes:
+                      </span>
+                      <span>
+                        Finished logic chip
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N81"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Burn-in test equipment
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N83"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Handlers and probes
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N82"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Linear and discrete testing tools
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <div>
+                            <div
+                              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-sub-node css-ee20y-MuiPaper-root"
+                              id="N80"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 node-heading css-ahj2mt-MuiTypography-root"
+                              >
+                                <span
+                                  class="graph-node-icon"
+                                  style="margin-left: 0px;"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1m9ymud-MuiSvgIcon-root"
+                                    focusable="false"
+                                    id="a"
+                                    style="fill-rule: evenodd; margin: -8px 0px;"
+                                    viewBox="0 0 44 44"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      class="b"
+                                      d="M13.75,29.7c-.2,.11-.46,.04-.57-.16l-2.12-3.68c-.11-.2-.05-.46,.15-.58l1.88-1.15c.2-.12,.36-.4,.36-.64v-3c0-.23-.16-.52-.36-.64l-1.88-1.15c-.2-.12-.26-.38-.15-.58l2.12-3.68c.11-.2,.38-.27,.57-.16l1.94,1.05c.2,.11,.53,.11,.73,0l2.6-1.5c.2-.12,.37-.4,.37-.63l.06-2.21c0-.23,.2-.42,.43-.42h4.24c.23,0,.42,.19,.43,.41l.06,2.21c0,.23,.17,.51,.37,.63l2.6,1.5c.2,.12,.53,.12,.73,0l1.94-1.06c.2-.11,.46-.04,.57,.16l2.12,3.68c.11,.2,.05,.46-.15,.58l-1.88,1.15c-.2,.12-.36,.4-.36,.64v3c0,.23,.16,.52,.36,.64l1.88,1.15c.2,.12,.26,.38,.15,.58l-2.12,3.68c-.11,.2-.38,.27-.57,.16l-1.94-1.05c-.2-.11-.53-.11-.73,0l-2.6,1.5c-.2,.12-.37,.4-.37,.63l-.06,2.21c0,.23-.2,.42-.43,.42h-4.24c-.23,0-.42-.19-.43-.41l-.06-2.21c0-.23-.17-.51-.37-.63l-2.6-1.5c-.2-.12-.53-.12-.73,0l-1.94,1.06Zm5.74-3.37c2.4,1.38,5.46,.56,6.84-1.83,1.38-2.4,.56-5.46-1.83-6.84-2.4-1.38-5.46-.56-6.84,1.83-1.38,2.4-.56,5.46,1.83,6.84Z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  SoC test equipment
+                                </span>
+                              </p>
+                            </div>
+                            <div
+                              class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                            >
+                              <div />
+                            </div>
+                          </div>
+                        </div>
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
+          </div>
+          <div
+            class="stage-border uncolored"
+          >
+            <div
+              class="graph-node-wrapper"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 graph-node css-ee20y-MuiPaper-root"
+                id="N99"
+                style="margin: 20px 25px 20px 25px; display: inline-block; width: 320px;"
+              >
+                <div
+                  style="text-align: left;"
+                >
+                  <div>
+                    <h3
+                      class="MuiTypography-root MuiTypography-body1 css-ahj2mt-MuiTypography-root"
+                    >
+                      Finished logic chip
+                    </h3>
+                  </div>
+                  <div
+                    class="graph-node-connections-text"
+                  >
+                    <div
+                      class="connection-text"
+                    >
+                      <span
+                        class="bold"
+                      >
+                        Input processes:
+                      </span>
+                      <span>
+                        Testing
+                      </span>
+                    </div>
+                  </div>
+                  <div>
+                    <div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-e784if-MuiTypography-root"
+                      >
+                        <div />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="documentation-node-widescreen"
+            />
           </div>
         </div>
       </div>
-    </footer>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/supply-chain/src/components/dashboard.js
+++ b/supply-chain/src/components/dashboard.js
@@ -3,7 +3,7 @@ import { useStaticQuery, graphql } from "gatsby"
 import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
-import {InfoCard, AppWrapper, Autocomplete, Dropdown, HelpTooltip, UserFeedback} from "@eto/eto-ui-components";
+import {InfoCard, Autocomplete, Dropdown, HelpTooltip, UserFeedback} from "@eto/eto-ui-components";
 import {useXarrow} from "react-xarrows";
 
 import Map from "./map";
@@ -434,7 +434,7 @@ const Dashboard = () => {
   /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, []);
 
-  return (<AppWrapper>
+  return (<>
     <div style={{maxWidth: "1500px"}}>
       <InfoCard
         title={"Supply Chain Explorer"}
@@ -495,7 +495,7 @@ const Dashboard = () => {
         documentationPanelToggle={documentationPanelToggle} setDocumentationPanelToggle={setDocumentationPanelToggle}
         parentNode={parentNode} selectedNode={selectedNode} updateSelected={updateSelected} />
     </div>
-  </AppWrapper>);
+  </>);
 };
 
 export default Dashboard;

--- a/supply-chain/src/pages/index.js
+++ b/supply-chain/src/pages/index.js
@@ -3,7 +3,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 import { ThemeProvider, createTheme } from '@mui/material';
 /* Set the body margin and padding to 0 here */
 import "../styles/styles.scss";
-import {ErrorBoundary} from "@eto/eto-ui-components";
+import { AppWrapper, ErrorBoundary } from "@eto/eto-ui-components";
 
 const theme = createTheme({
   components: {
@@ -25,15 +25,17 @@ const IndexPage = ({data}) => {
   }, []);
 
   return (
-    <ThemeProvider theme={theme}>
-      {(typeof window !== "undefined") &&
-        <React.Suspense fallback={<div style={{textAlign: "center"}}><CircularProgress/></div>}>
-          <ErrorBoundary>
-            <Dashboard/>
-          </ErrorBoundary>
-        </React.Suspense>
-      }
-    </ThemeProvider>
+    <AppWrapper>
+      <ThemeProvider theme={theme}>
+        {(typeof window !== "undefined") &&
+          <React.Suspense fallback={<div style={{textAlign: "center"}}><CircularProgress/></div>}>
+            <ErrorBoundary>
+              <Dashboard/>
+            </ErrorBoundary>
+          </React.Suspense>
+        }
+      </ThemeProvider>
+    </AppWrapper>
   )
 };
 


### PR DESCRIPTION
Including `<AppWrapper>` in the component files causes issues when running tests (see UIC issue 425), and also leads to the contents of `<Header>` and `<Footer>` being unnecessarily tested repeatedly in final applications.  Move AppWrapper to the page files and simplify the snapshots.

See https://github.com/georgetown-cset/eto-ui-components/issues/425