### PR TITLE
Add company-level graphs

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -350,9 +350,7 @@ class Preprocess:
                 else:
                     if provider_id not in self.org_provision:
                         self.org_provision[provider_id] = {}
-                    self.org_provision[provider_id][provided] = self.get_provision(
-                        line, True
-                    )
+                    self.org_provision[provider_id][provided] = self.get_provision(line)
                     if self.node_to_meta.get(provided, {}).get("type") == "process":
                         process_nodes_with_org_provision.add(provided)
         country_provision_concentration = self.get_provision_concentration(

--- a/supply-chain/src/components/ProviderGraph.tsx
+++ b/supply-chain/src/components/ProviderGraph.tsx
@@ -3,18 +3,19 @@ import Typography from '@mui/material/Typography';
 
 import { HelpTooltip, PlotlyDefaults } from '@eto/eto-ui-components';
 
-import { countryFlags } from "../../data/provision";
 import ProviderTable from "./ProviderTable";
 import "./ProviderTable.css";
 
 const Plot = lazy(() => import('react-plotly.js'));
 
 interface ProviderWithProvisionValue {
-  country: string;
+  flag?: string;
+  provider: string;
   value: number;
 }
 interface ProviderWithoutProvisionValue {
-  country: string;
+  flag?: string;
+  provider: string;
   value: string;
 }
 type Provider = ProviderWithProvisionValue | ProviderWithoutProvisionValue;
@@ -27,57 +28,47 @@ export interface ProviderGraphProps {
   tooltip?: ReactNode;
 }
 
-const ProviderGraph = (props: ProviderGraphProps) => {
-  const {
-    marketShareCaption,
-    marketShareSource,
-    providers,
-    title,
-    tooltip,
-  } = props;
+const ProviderGraph = ({
+  marketShareCaption,
+  marketShareSource,
+  providers,
+  title,
+  tooltip,
+}: ProviderGraphProps) => {
+  const hasProviders = (providers !== null) && (providers !== undefined) && (providers.length > 0);
 
-  const graphProviders: Array<ProviderWithProvisionValue> = [];
-  const minorProviders: Array<ProviderWithoutProvisionValue> = [];
-  const hasCountries = (providers !== null) && (providers !== undefined) && (providers.length > 0);
-
-  if ( hasCountries ) {
-    for (let i = 0; i < providers.length; i++) {
-      if (typeof providers[i].value !== "number") {
-        minorProviders.push(providers[i] as ProviderWithoutProvisionValue);
-      } else {
-        graphProviders.push(providers[i] as ProviderWithProvisionValue);
-      }
-    }
-  } else {
+  if ( ! hasProviders ) {
     // Don't display the graph component if we have no data.
     return null;
   }
 
-  graphProviders.sort((a, b) => {
-    // Country nodes for "Various" always go last
-    if (a.country === "Various") {
-      return -1;
-    } else if (b.country === "Various") {
-      return 1;
-    // Otherwise, sort by value in descending order
-    } else if (a.value > b.value) {
-      return 1;
-    } else if (b.value > a.value) {
-      return -1;
-    } else {
-      return 0;
-    }
-  });
+  const graphProviders = providers
+    .filter(provider => typeof provider.value === "number")
+    .map(provider => provider as ProviderWithProvisionValue)
+    .toSorted((a, b) => {
+      // Nodes for "Various" always go last
+      if ( a.provider.startsWith("Various") ) {
+        return -1;
+      } else if ( b.provider.startsWith("Various") ) {
+        return 1;
+      // Otherwise, sort by value in descending order
+      } else if (a.value > b.value) {
+        return 1;
+      } else if (b.value > a.value) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
 
-  const minorProviderList = minorProviders.map(({ country }) => ({
-    provider: country,
-    flag: countryFlags[country],
-  }));
+  const minorProviders = providers
+    .filter(provider => typeof provider.value !== "number")
+    .map(provider => provider as ProviderWithoutProvisionValue);
 
   const data = [
     {
       x: graphProviders.map(e => e.value),
-      y: graphProviders.map(e => e.country),
+      y: graphProviders.map(e => e?.flag ? `${e.provider} ${e?.flag}` : e.provider),
       type: "bar",
       orientation: "h",
       hovertemplate: '%{x}%<extra></extra>',
@@ -118,13 +109,13 @@ const ProviderGraph = (props: ProviderGraphProps) => {
       }
       {graphProviders.length > 0 && minorProviders.length > 0 &&
         <Typography component={"p"} variant={"body2"} style={{marginTop: "20px"}}>
-          Minor providers (not pictured): {minorProviders.map(c => c.country).join(", ")}
+          Minor providers (not pictured): {minorProviders.map(c => c.provider).join(", ")}
         </Typography>
       }
       {graphProviders.length === 0 && minorProviders.length > 0 &&
         <ProviderTable
           caption={title}
-          providers={minorProviderList}
+          providers={minorProviders}
           tooltip={tooltip}
         />
       }

--- a/supply-chain/src/components/ProviderTable.css
+++ b/supply-chain/src/components/ProviderTable.css
@@ -9,6 +9,10 @@
   font-size: 1.25rem;
   font-weight: 900;
   margin: 10px 0 0;
+
+  svg {
+    vertical-align: text-bottom;
+  }
 }
 
 .provider-table table {

--- a/supply-chain/src/components/ProviderTable.tsx
+++ b/supply-chain/src/components/ProviderTable.tsx
@@ -8,7 +8,7 @@ import "./ProviderTable.css";
 
 export interface ProvidersEntry {
   details?: ReactNode;
-  flag: string;
+  flag?: string;
   provider: string;
 }
 export interface ProviderTableProps {

--- a/supply-chain/src/components/input_detail.js
+++ b/supply-chain/src/components/input_detail.js
@@ -1,6 +1,10 @@
 import React from "react";
 import ReactMarkdown from 'react-markdown'
 import Typography from "@mui/material/Typography";
+import {
+  CorporateFare as CorporateFareIcon,
+  Public as PublicIcon,
+} from "@mui/icons-material";
 
 import mdxComponents from "../helpers/mdx_style";
 import tooltips from "../helpers/tooltips";
@@ -12,7 +16,7 @@ import ProviderGraph from "./ProviderGraph";
 
 const InputDetail = (props) => {
   const {
-    countries,
+    countries = [],
     description,
     orgs,
     orgMeta,
@@ -23,15 +27,22 @@ const InputDetail = (props) => {
     variantOrgs,
   } = props;
 
+  const countryList = countries.map(({ country, value }) => ({
+    provider: country,
+    flag: countryFlags[country],
+    value,
+  }));
+
   const variantCountryList = Object.keys(variantCountries).map((country) => ({
     provider: country,
     flag: countryFlags[country],
     details: "Provides: " + variantCountries?.[country].map(e => nodeToMeta[e].name).join(", "),
   }));
 
-  const orgList = Object.keys(orgs ?? {}).map(e => ({
-    provider: orgMeta[e].name,
-    flag: orgMeta[e].hq_flag,
+  const orgList = Object.entries(orgs ?? {}).map(([orgId, value]) => ({
+    provider: orgMeta[orgId].name,
+    flag: orgMeta[orgId].hq_flag,
+    value,
   }));
 
   const variantOrgList = Object.keys(variantOrgs).map((org) => ({
@@ -51,14 +62,15 @@ const InputDetail = (props) => {
       <ProviderGraph
         marketShareCaption={nodeToMeta[selectedNode].market_chart_caption}
         marketShareSource={nodeToMeta[selectedNode].market_chart_source}
-        providers={countries}
-        title="Supplier countries"
+        providers={countryList}
+        title={<><PublicIcon /> Supplier countries</>}
         tooltip={tooltips.providers.countries}
       />
 
-      <ProviderTable
-        caption="Notable supplier companies"
+      <ProviderGraph
+        // TODO - Jacob - do you want market share caption/sources?
         providers={orgList}
+        title={ <><CorporateFareIcon /> Supplier companies</> }
         tooltip={tooltips.providers.orgs}
       />
       {variants[selectedNode] &&
@@ -72,12 +84,12 @@ const InputDetail = (props) => {
             updateSelected={updateSelected}
           />
           <ProviderTable
-            caption="Supplier Countries (Variants)"
+            caption={<><PublicIcon /> Supplier countries</>}
             providers={variantCountryList}
             tooltip={tooltips.providers.countries}
           />
           <ProviderTable
-            caption="Notable supplier companies (Variants)"
+            caption={ <><CorporateFareIcon /> Supplier companies</> }
             providers={variantOrgList}
             tooltip={tooltips.providers.orgs}
           />


### PR DESCRIPTION
Update preprocessing script to expect numbers from companies.  Add company-level graphs to the nodes, alongside existing country graphs (closes #590).  Remove "variants" text from headings (closes #629).